### PR TITLE
Quick Mockup of a Generic Search Screen

### DIFF
--- a/VisualChallenge/VisualChallenge.Android/VisualChallenge.Android.csproj
+++ b/VisualChallenge/VisualChallenge.Android/VisualChallenge.Android.csproj
@@ -15,7 +15,6 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>

--- a/VisualChallenge/VisualChallenge/VisualChallengePage.xaml
+++ b/VisualChallenge/VisualChallenge/VisualChallengePage.xaml
@@ -1,19 +1,41 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
              x:Class="VisualChallenge.VisualChallengePage"
-             Shell.NavBarIsVisible="True"
+             Shell.NavBarIsVisible="False"
              BackgroundColor="White"
-             Title="Visual Challenge"
-             >
-
-    <FlexLayout Margin="20" Direction="Column" AlignContent="Center" JustifyContent="SpaceAround">
-
-        <Label Text="Start Here" FontSize="24" HorizontalTextAlignment="Center"/>
-
-        <Button Text="Read More About Visual" Clicked="Button_Clicked" />
-
-    </FlexLayout>
+             Title="Visual Challenge">
+             
+    <StackLayout BackgroundColor="White" HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand">
+        <StackLayout Padding="20" BackgroundColor="Teal" HeightRequest="200" HorizontalOptions="FillAndExpand" VerticalOptions="StartAndExpand">
+            <Label Text="Find Something" FontSize="32" TextColor="White" VerticalOptions="EndAndExpand" HorizontalOptions="FillAndExpand" />
+            <Entry BackgroundColor="White" TextChanged="Handle_TextChanged" HorizontalOptions="FillAndExpand" VerticalOptions="End" />
+        </StackLayout>
+        
+        <ScrollView>
+            <CollectionView x:Name="Results">
+                <CollectionView.EmptyView>
+                    <Label HorizontalTextAlignment="Center" HorizontalOptions="CenterAndExpand" Text="I give you nothing." />
+                </CollectionView.EmptyView>
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <StackLayout Padding="20" VerticalOptions="StartAndExpand" HorizontalOptions="FillAndExpand">
+                            <Frame> <!-- Margin="20" didn't work -->
+                                <StackLayout VerticalOptions="StartAndExpand" HorizontalOptions='FillAndExpand' Orientation="Horizontal">
+                                    <Image Source="{Binding Image}" HeightRequest="50" WidthRequest="50" VerticalOptions="Center" HorizontalOptions="Start" />
+                                    <StackLayout VerticalOptions="StartAndExpand" HorizontalOptions="StartAndExpand" Orientation="Vertical">
+                                        <Label Text="{Binding Name}" VerticalOptions="Start" HorizontalOptions="FillAndExpand" FontSize="24" />
+                                        <Label Text="{Binding ShortDescription}" VerticalOptions="Start" HorizontalOptions="FillAndExpand" TextColor="Gray" />
+                                    </StackLayout>
+                                </StackLayout>
+                            </Frame>
+                        </StackLayout>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </ScrollView>
+        
+    </StackLayout>
     
 </ContentPage>

--- a/VisualChallenge/VisualChallenge/VisualChallengePage.xaml.cs
+++ b/VisualChallenge/VisualChallenge/VisualChallengePage.xaml.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
@@ -7,14 +10,41 @@ namespace VisualChallenge
 {
     public partial class VisualChallengePage : ContentPage
     {
-        public VisualChallengePage()
+		ObservableCollection<MyItem> MyItems = new ObservableCollection<MyItem>();
+
+		IList<MyItem> Data = new List<MyItem>()
+		{
+			new MyItem() { Name = "Carrots", ShortDescription = "Long orange things", Image = "http://befreshcorp.net/wp-content/uploads/2017/06/product-packshot-Carrot-558x600.jpg" },
+			new MyItem() { Name = "Tomato", ShortDescription = "Round red...fruit?", Image = "https://food.fnr.sndimg.com/content/dam/images/food/fullset/2014/8/19/0/HE_tomato-with-stem-thinkstock.jpg.rend.hgtvcom.616.493.suffix/1408469205509.jpeg" },
+			new MyItem() { Name = "Bread", ShortDescription = "All the carbs", Image = "https://images-na.ssl-images-amazon.com/images/I/51fgwfyhrxL._SX425_.jpg" },
+			new MyItem() { Name = "Apple", ShortDescription = "For the doctor", Image = "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTsxnZZoL7FC4FucFZo5ua8k39HRPg2PdbG1asTSAiO02UD4Y0Q" },
+			new MyItem() { Name = "Chicken", ShortDescription = "He didn't make it across the road...", Image = "https://media.istockphoto.com/photos/chicken-and-egg-picture-id478796565?k=6&m=478796565&s=612x612&w=0&h=avEnw9FQbSl4l5RAbLK2oBMxvbRSbzxQ0PEVPTP2PvA=" }
+		};
+
+		public VisualChallengePage()
         {
             InitializeComponent();
-        }
 
-        private void Button_Clicked(object sender, EventArgs e)
-        {
-            Device.OpenUri(new Uri("https://docs.microsoft.com/en-us/xamarin/xamarin-forms/user-interface/visual"));
-        }
-    }
+			Results.ItemsSource = MyItems;
+		}
+
+		void Handle_TextChanged(object sender, Xamarin.Forms.TextChangedEventArgs e)
+		{
+			MyItems.Clear();
+			if (Data.Any(d => d.Name.Contains(e.NewTextValue)))
+			{
+				foreach (var item in Data.Where(d => d.Name.Contains(e.NewTextValue)))
+					MyItems.Add(item);
+			}
+		}
+	}
+
+	class MyItem
+	{
+		public string Name { get; set; }
+
+		public string ShortDescription { get; set;  }
+
+		public string Image { get; set; }
+	}
 }


### PR DESCRIPTION
Working on a project now where we just need to search simple data.  Looks a little something what I was able to come up with here.

**Results:**
![image](https://user-images.githubusercontent.com/4753021/52678616-48d5fe00-2f00-11e9-826f-16797b8b7161.png)
![image](https://user-images.githubusercontent.com/4753021/52678883-24c6ec80-2f01-11e9-9370-b73a9afed00c.png)


### Problems
- Was using Visual Studio for Mac and XAML Preview doesn't work if it has elements that require Xamarin Experimental Flags
- CollectionView is definitely still in preview.  On iOS if you change the `ItemSource` more than once it crashes.  Android worked fine.
- `Frame` margin didn't work, so I had to wrap it in a `StackLayout`.  See comments in XAML
- The default size of `Entry` seemed tall.  The text doesn't even fill it up.  Maybe this is by default, but it just seemed... big.

### Good things
- The design between Android/iOS is extremely similar compared to past Xamarin projects and makes me feel better about working with mostly 1 device during the design process until the end.
- `Shell.NavBarIsVisible` is a nice touch.  Probably other ways of doing it before shell, but it was right there and easy.

### Additional Notes
The real killer was the XAML preview not working.  I'm attaching the error below to make sure it isn't just me, but having to start the simulator every few minutes after a change really slowed down home much I could do in an hour.

![image](https://user-images.githubusercontent.com/4753021/52678947-5d66c600-2f01-11e9-9ef3-12dcc038aedf.png)
