### PR TITLE
Visual Challenge - Airbnb Home UI

### DIFF
--- a/VisualChallenge/VisualChallenge.Android/ExtendedSearchBar.cs
+++ b/VisualChallenge/VisualChallenge.Android/ExtendedSearchBar.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Android.Content;
+using VisualChallenge.Droid;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Android;
+
+[assembly: ExportRenderer(typeof(SearchBar), typeof(ExtendedSearchBar))]
+namespace VisualChallenge.Droid
+{
+    public class ExtendedSearchBar: SearchBarRenderer
+    {
+        public ExtendedSearchBar(Context context) : base(context)
+        {
+        }
+
+        protected override void OnElementChanged(ElementChangedEventArgs<SearchBar> e)
+        {
+            base.OnElementChanged(e);
+
+            if(this.Control!= null)
+            {
+                var searchId = Resources.GetIdentifier("android:id/search_plate", null, null);
+                var search = Control.FindViewById(searchId);
+                search.SetBackgroundColor(Android.Graphics.Color.Transparent);
+            }
+
+        }
+    }
+}

--- a/VisualChallenge/VisualChallenge.Android/VisualChallenge.Android.csproj
+++ b/VisualChallenge/VisualChallenge.Android/VisualChallenge.Android.csproj
@@ -57,6 +57,7 @@
     <Compile Include="MainActivity.cs" />
     <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ExtendedSearchBar.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />

--- a/VisualChallenge/VisualChallenge/App.xaml
+++ b/VisualChallenge/VisualChallenge/App.xaml
@@ -1,8 +1,44 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <Application xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="VisualChallenge.App">
     <Application.Resources>
-        
+        <ResourceDictionary>
+              
+            <Style TargetType="Label" x:Key="TitleStyle" >
+                 <Setter Property="VerticalOptions" Value="Start"  />
+                 <Setter Property="FontSize" Value="Large" />
+                 <Setter Property="FontAttributes" Value="Bold" />
+                <Setter Property="Margin" Value="0,30,0,0" />
+            </Style>
+            
+             <Style TargetType="Label" x:Key="DescriptionStyle" >
+                 <Setter Property="VerticalOptions" Value="Start"  />
+                 <Setter Property="FontSize" Value="14" />
+                 <Setter Property="FontAttributes" Value="Bold" />
+                 <Setter Property="Margin" Value="10,0" />
+                 <Setter Property="LineBreakMode" Value="TailTruncation" />
+            </Style>
+            
+             <Style TargetType="Label" x:Key="TagStyle"  BasedOn="{StaticResource DescriptionStyle}">
+                 <Setter Property="TextColor" Value="RoyalBlue"  />
+            </Style>
+            
+            <Style TargetType="Button" x:Key="FilterButtonStyle" >
+                 <Setter Property="TextColor" Value="Gray"  />
+                 <Setter Property="HorizontalOptions" Value="Start" />
+                 <Setter Property="BackgroundColor" Value="White" />
+                 <Setter Property="BorderColor" Value="LightGray" />
+                 <Setter Property="BorderWidth" Value="1" />
+                 <Setter Property="CornerRadius" Value="5" />
+                 <Setter Property="Padding" Value="10,0" />
+                 <Setter Property="Visual" Value="Default" />
+            </Style>
+            
+            <Style TargetType="Button" x:Key="FilterSelectedButtonStyle"  BasedOn="{StaticResource FilterButtonStyle}">
+                 <Setter Property="TextColor" Value="White"  />
+                 <Setter Property="BackgroundColor" Value="#3A888D" />
+            </Style>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/VisualChallenge/VisualChallenge/Place.cs
+++ b/VisualChallenge/VisualChallenge/Place.cs
@@ -1,0 +1,17 @@
+﻿using System;
+namespace VisualChallenge
+{
+    public class Place
+    {
+        public string Name { get; set; }
+        public string Photo { get; set; }
+        public double Price { get; set; }
+        public string Tag { get; set; }
+    }
+
+    public class PlaceType
+    {
+        public string Name { get; set; }
+        public string Photo { get; set; }
+    }
+}

--- a/VisualChallenge/VisualChallenge/VisualChallenge.sln
+++ b/VisualChallenge/VisualChallenge/VisualChallenge.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualChallenge", "VisualChallenge.csproj", "{E143A1D5-CE70-417F-8B80-1A5BA779D5FE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E143A1D5-CE70-417F-8B80-1A5BA779D5FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E143A1D5-CE70-417F-8B80-1A5BA779D5FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E143A1D5-CE70-417F-8B80-1A5BA779D5FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E143A1D5-CE70-417F-8B80-1A5BA779D5FE}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/VisualChallenge/VisualChallenge/VisualChallengePage.xaml
+++ b/VisualChallenge/VisualChallenge/VisualChallengePage.xaml
@@ -1,23 +1,113 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
              x:Class="VisualChallenge.VisualChallengePage"
-             Shell.NavBarIsVisible="True"
-             BackgroundColor="White"
-             Title="Visual Challenge"
-             >
-
-	<!-- If you decide to change out the flexlayout leave the scroll view here
-		 Currently there's a bug in shell that will set margins wrong if the content is not in a scrollview
-	-->
-	<ScrollView>
-		<FlexLayout Margin="20" Direction="Column" AlignContent="Center" JustifyContent="SpaceAround">
-
-			<Label Text="Start Here" FontSize="24" HorizontalTextAlignment="Center"/>
-
-			<Button Text="Read More About Visual" Clicked="Button_Clicked" />
-
-		</FlexLayout>
-	</ScrollView>
+             Shell.NavBarIsVisible="False"
+             BackgroundColor="White">
+    <ScrollView Padding="0,20,0,0">
+		<Grid Margin="20,20,0,20" 
+              RowSpacing="10">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+             <Frame Padding="0"
+                    Margin="0,0,20,0"
+                    HorizontalOptions="FillAndExpand"
+                    Grid.Row="0"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="2">
+                 <SearchBar BackgroundColor="Transparent"
+                            HorizontalOptions="FillAndExpand"
+                            Placeholder="Try 'Dominican Republic'"/>
+            </Frame>
+            
+             <Button Text="Dates"
+                     Grid.Row="1"
+                     Grid.Column="0"
+                     Style="{StaticResource FilterButtonStyle}"/>
+            
+             <Button Text="{Binding GuestsQuantity, StringFormat=' {0} guest'}"
+                     HorizontalOptions="Start"
+                     Grid.Row="1"
+                     Grid.Column="1"
+                     Style="{StaticResource FilterSelectedButtonStyle}"/> 
+            
+               <Label Text="What can we help you find, Charlin?"
+                      Style="{StaticResource TitleStyle}"
+                      Grid.Row="2"
+                      Grid.Column="0"
+                      Grid.ColumnSpan="2"/>
+            
+            <ScrollView Grid.Row="3"
+                        HorizontalOptions="FillAndExpand"
+                        Grid.Column="0"
+                        Grid.ColumnSpan="2"
+                        Padding="0"
+                        Orientation="Horizontal"
+                        HorizontalScrollBarVisibility="Never">
+                <StackLayout Orientation="Horizontal"
+                             BindableLayout.ItemsSource="{Binding PlaceTypes}">
+                   <BindableLayout.ItemTemplate>
+                    <DataTemplate>
+                         <Frame Padding="0,0,0,20"
+                                Margin="0,0,20,0" >
+                            <StackLayout>
+                                    <Image Source="{Binding Photo}"
+                                           HeightRequest="120"
+                                           Aspect="AspectFill"
+                                           WidthRequest="150"/>
+                                    <Label Text="{Binding Name}"
+                                           Style="{StaticResource DescriptionStyle}"/>
+                                </StackLayout>
+                        </Frame>
+                    </DataTemplate>
+                </BindableLayout.ItemTemplate>
+               </StackLayout>
+          </ScrollView>
+            
+            <Label Text="Places near your home"
+                   Style="{StaticResource TitleStyle}"
+                   Grid.Row="4"
+                   Grid.Column="0"
+                   Grid.ColumnSpan="2"/>
+            
+           <ScrollView Grid.Row="5"
+                       Grid.Column="0"
+                       Grid.ColumnSpan="2"
+                       Orientation="Horizontal"
+                       HorizontalScrollBarVisibility="Never">
+            <StackLayout Orientation="Horizontal"
+                      BindableLayout.ItemsSource="{Binding Places}">
+               <BindableLayout.ItemTemplate>
+                <DataTemplate>
+                       <Frame Padding="0,0,0,20"
+                              WidthRequest="150"
+                              Margin="0,0,20,0" >
+                            <StackLayout Spacing="5">
+                                    <Image Source="{Binding Photo}"
+                                           HeightRequest="120"
+                                           Aspect="AspectFill"
+                                           WidthRequest="150"/>
+                                     <Label Text="{Binding Tag}"
+                                            Style="{StaticResource TagStyle}"/>
+                                    <Label Text="{Binding Name}"
+                                           Style="{StaticResource DescriptionStyle}"/>
+                                </StackLayout>
+                        </Frame>
+                </DataTemplate>
+            </BindableLayout.ItemTemplate>
+           </StackLayout>
+         </ScrollView>
+		</Grid>
+     </ScrollView>
 </ContentPage>

--- a/VisualChallenge/VisualChallenge/VisualChallengePage.xaml.cs
+++ b/VisualChallenge/VisualChallenge/VisualChallengePage.xaml.cs
@@ -10,6 +10,7 @@ namespace VisualChallenge
         public VisualChallengePage()
         {
             InitializeComponent();
+            this.BindingContext = new VisualChallengePageViewModel();
         }
 
         private void Button_Clicked(object sender, EventArgs e)

--- a/VisualChallenge/VisualChallenge/VisualChallengePageViewModel.cs
+++ b/VisualChallenge/VisualChallenge/VisualChallengePageViewModel.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.ObjectModel;
+
+namespace VisualChallenge
+{
+    public class VisualChallengePageViewModel
+    {
+        public int GuestsQuantity { get; set; } = 1;
+        public string UserName { get; set; }
+        public ObservableCollection<Place> Places { get; set; }
+        public ObservableCollection<PlaceType> PlaceTypes { get; set; }
+        public VisualChallengePageViewModel()
+        {
+            Places = new ObservableCollection<Place>()
+            {
+                {new Place(){ Name="Charming Traditional House", Price=103, Photo="https://puu.sh/D58Wz/6d6d76734b.png", Tag="CULTURE"}},
+                {new Place(){ Name="Home with Pool", Price=103, Photo="https://puu.sh/D58WN/1a1050e632.png", Tag="POOL"}},
+                {new Place(){ Name="Full Apartament", Price=200, Photo="https://puu.sh/D58Xg/d8a6825af1.png", Tag="ROMANTIC"}}
+            };
+
+
+            PlaceTypes = new ObservableCollection<PlaceType>()
+            {
+                {new PlaceType(){ Name="Homes", Photo="https://puu.sh/D58FT/69a1d82e23.png"}},
+                 {new PlaceType(){ Name="Experiences", Photo="https://puu.sh/D58Gg/5a285502b9.png"}},
+                  {new PlaceType(){ Name="Restaurants", Photo="https://puu.sh/D58GX/f6e7317c6a.png"}}
+            };
+        }
+    }
+}


### PR DESCRIPTION
 I was trying to replicate the Arbnb Home UI
<img width="361" alt="Screen Shot 2019-03-25 at 12 35 00 PM" src="https://user-images.githubusercontent.com/5597782/54937298-87e17100-4efa-11e9-8ed0-e041c3e8a7b7.png">

Result: 
![1fcacb7d-a7a6-4dbe-9473-04f8c4ba46f4 (3)](https://user-images.githubusercontent.com/5597782/54937759-659c2300-4efb-11e9-8a83-0bc3def5de4b.png)

**What went well:** 
 - Love the material frames style on iOS
 - In the original Airbnb design buttons weren't using material design spec. So I liked the ability to set them as Visual Default.

 **What didn't:** 
 - I have an issue with the Frame inside a Bindable Layout + ScrollView, when adding the ScrollView the frame lines are thiner, here is a screenshot (The first layout has a ScrollView and the second don't): 

<img width="407" alt="visual" src="https://user-images.githubusercontent.com/5597782/54938499-d6900a80-4efc-11e9-9e60-c95d82b9cca6.png">


Not sure if this is reported yet.

**Want to see next:** 
- More Shadows customizations in the Frames 
- Corner radius customization, ability to set the radius of each border 
- Navigation Bar should have the shadow option on iOS
- Navigation Bar Hide/Show when scrolling (https://material.io/design/components/app-bars-top.html#behavior)

