### PR TITLE
[Visual Challenge] Requests Page

### DIFF
--- a/VisualChallenge/VisualChallenge/Models/DashboardItem.cs
+++ b/VisualChallenge/VisualChallenge/Models/DashboardItem.cs
@@ -1,0 +1,11 @@
+﻿using System;
+namespace VisualChallenge.Models
+{
+    public class DashboardItem
+    {
+        public string ImageUrl { get; set; }
+        public string Number { get; set; }
+        public string Description { get; set; }
+
+    }
+}

--- a/VisualChallenge/VisualChallenge/Models/Item.cs
+++ b/VisualChallenge/VisualChallenge/Models/Item.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace VisualChallenge.Models
+{
+    public class Item
+    {
+        public string Id { get; set; }
+        public string Subject { get; set; }
+        public string Status { get; set; }
+    }
+}

--- a/VisualChallenge/VisualChallenge/VisualChallenge.csproj
+++ b/VisualChallenge/VisualChallenge/VisualChallenge.csproj
@@ -20,4 +20,7 @@
       <DependentUpon>VisualChallengePage.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Models\" />
+  </ItemGroup>
 </Project>

--- a/VisualChallenge/VisualChallenge/VisualChallengePage.xaml
+++ b/VisualChallenge/VisualChallenge/VisualChallengePage.xaml
@@ -12,7 +12,7 @@
         Currently there's a bug in shell that will set margins wrong if the content is not in a scrollview
     -->
     <ScrollView>
-            <StackLayout>
+            <StackLayout Spacing="5">
             
             <Grid BackgroundColor="White" RowSpacing="15">
                 <Grid.RowDefinitions>
@@ -71,51 +71,124 @@
                 
                 
         </Grid>
+            
+            
+            <CollectionView ItemsLayout="{x:Static ListItemsLayout.HorizontalList}"   
+                            VerticalOptions="Center"
+                            Margin="5,15,5,0"
+                            HeightRequest="155"
+                            ItemSizingStrategy="MeasureFirstItem"
+                            ItemsSource="{Binding DashboardItems}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>                        
+                        <ContentView> <!-- Notice the additional ContentView here -->
+                            <Frame BackgroundColor="White"
+                                   HeightRequest="150"
+                                   WidthRequest="110"
+                                   Margin="10,0,10,0"
+                                   Visual="Material"
+                                   Padding="10"
+                                   IsClippedToBounds="True">
+                        
+                        
+                                <Grid RowSpacing="5">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="*" />
+                                    </Grid.RowDefinitions>
+                                    
+                                     <Image Source="{Binding ImageUrl}"
+                                            VerticalOptions="Start"
+                                            HorizontalOptions="Start"/>
+                                    
+                                     <Label Grid.Row="1"   
+                                            Margin="0,10,0,0"
+                                            VerticalOptions="Center"
+                                            FontSize="25"
+                                            Text="{Binding Number}" />
+                                     <Label Grid.Row="2" 
+                                            VerticalOptions="Start"
+                                            FontSize="14"
+                                            TextColor="Gray"
+                                            Text="{Binding Description}" />
 
-            <Label FontSize="24"
-                   Text="ABC"
-                   HorizontalTextAlignment="Center"/>
+                                    
+                                </Grid>
+                            </Frame>
+                        </ContentView>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
 
+          
+          
+            <Grid Margin="25,20,10,0">
+                <Grid.ColumnDefinitions>
+                     <ColumnDefinition Width="35" />
+                     <ColumnDefinition Width="4*" />
+                     <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                    <Label Grid.Column="0"
+                           VerticalOptions="Center"
+                           TextColor="Gray"
+                           FontSize="12"
+                           Text="ID" />
+                    <Label Grid.Column="1"
+                           HorizontalOptions="Start"
+                           VerticalOptions="Center"
+                           TextColor="Gray"
+                           FontSize="12"
+                           Text="SUBJECT" />
 
+                
+            </Grid>
 
                    <!-- CollectionView header and footer?-->
-            <CollectionView ItemsLayout="{x:Static ListItemsLayout.VerticalList}"                             
+            <CollectionView ItemsLayout="{x:Static ListItemsLayout.VerticalList}" 
+                            Margin="0,0,0,0"
+                            ItemSizingStrategy="MeasureFirstItem"
                             ItemsSource="{Binding Items}">
                 <CollectionView.ItemTemplate>
                     <DataTemplate>
                         
                         <ContentView> <!-- Notice the additional ContentView here -->
-                <Frame BackgroundColor="White"
-                    HeightRequest="35"
-                    Margin="10, 5"
-                       Visual="Material"
-                    Padding="10"
-                    IsClippedToBounds="True">
-                        
-                        
-                        <Grid VerticalOptions="Center">
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="35" />
-                            </Grid.RowDefinitions>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
+                            <Frame BackgroundColor="White"
+                                   HeightRequest="45"
+                                   Margin="10, 5"
+                                   Visual="Material"
+                                   Padding="10"
+                                   IsClippedToBounds="True">
+                                                
+                                    <Grid VerticalOptions="Center">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="45" />
+                                        </Grid.RowDefinitions>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="35" />
+                                            <ColumnDefinition Width="4*" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
 
-                            <Label Grid.Column="0"
-                                   VerticalOptions="Center"
-                                   FontAttributes="Bold"
-                                   Text="{Binding Id}" />
-                            <Label Grid.Column="1"
-                                   VerticalOptions="Center"
-                                   Text="{Binding Subject}" />
-                             <Label Grid.Column="2"
-                                    VerticalOptions="Center"
-                                   FontAttributes="Bold"
-                                   Text="{Binding Status}" />
-                                      
-                        </Grid>
+                                        <Label Grid.Column="0"
+                                               VerticalOptions="Center"
+                                               HorizontalOptions="Center"
+                                               FontAttributes="Bold"
+                                               FontSize="14"
+                                               Text="{Binding Id}" />
+                                        <Label Grid.Column="1"
+                                               HorizontalOptions="Start"
+                                               FontSize="14"
+                                               VerticalOptions="Center"
+                                               Text="{Binding Subject}" />
+                                         <Label Grid.Column="2"
+                                                FontSize="14"
+                                                TextColor="#385AF5"
+                                                VerticalOptions="Center"
+                                                FontAttributes="Bold"
+                                                Text="{Binding Status}" />
+                                                  
+                                    </Grid>
                                 </Frame>
                             </ContentView>
                     </DataTemplate>

--- a/VisualChallenge/VisualChallenge/VisualChallengePage.xaml
+++ b/VisualChallenge/VisualChallenge/VisualChallengePage.xaml
@@ -1,23 +1,128 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage x:Class="VisualChallenge.VisualChallengePage"
+             xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
-             x:Class="VisualChallenge.VisualChallengePage"
-             Shell.NavBarIsVisible="True"
-             BackgroundColor="White"
              Title="Visual Challenge"
-             >
+             BackgroundColor="#F4F6FB"
+             Shell.NavBarIsVisible="True">
 
-	<!-- If you decide to change out the flexlayout leave the scroll view here
-		 Currently there's a bug in shell that will set margins wrong if the content is not in a scrollview
-	-->
-	<ScrollView>
-		<FlexLayout Margin="20" Direction="Column" AlignContent="Center" JustifyContent="SpaceAround">
+    <!--
+        If you decide to change out the flexlayout leave the scroll view here
+        Currently there's a bug in shell that will set margins wrong if the content is not in a scrollview
+    -->
+    <ScrollView>
+            <StackLayout>
+            
+            <Grid BackgroundColor="White" RowSpacing="15">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                
+                
+                
+                <Grid ColumnSpacing="10" Margin="20,20,20,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="70"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    
+                    <!-- Round images is a must have by default-->
+                    <Image Source="https://blog.xamarin.com/wp-content/uploads/2017/04/monkey-MVP.png"
+                           VerticalOptions="Center"
+                           HorizontalOptions="Center"/>
+                    
+                    <StackLayout Grid.Column="1">
+                        
+                        <Label Text="Xamarin Monkey" 
+                               FontSize="18"
+                               FontAttributes="Bold"/>
+                        
+                        <Label Text="Senior Xamarin Developer" 
+                               FontSize="18"
+                               TextColor="Gray"/>
+                    </StackLayout>
+                    
+                </Grid>
+                
+                <Grid Grid.Row="1" 
+                      VerticalOptions="Center"
+                      HeightRequest="42"
+                      ColumnSpacing="20" Margin="20,0,20,20">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    
+                    <!-- TEXT ALL IN CAPS, SHOULDNT BE-->
+                    <Button Visual="Material" 
+                            TextColor="White"
+                            BackgroundColor="#385AF5"
+                            Text="View Profile"/>
+                    
+                    
+                    <Button Visual="Material" 
+                            BackgroundColor="#D6DDFC"
+                            TextColor="#3759F6"
+                            Grid.Column="1"
+                            Text="View Profile"/>
+                </Grid>
+                
+                
+        </Grid>
 
-			<Label Text="Start Here" FontSize="24" HorizontalTextAlignment="Center"/>
+            <Label FontSize="24"
+                   Text="ABC"
+                   HorizontalTextAlignment="Center"/>
 
-			<Button Text="Read More About Visual" Clicked="Button_Clicked" />
 
-		</FlexLayout>
-	</ScrollView>
+
+                   <!-- CollectionView header and footer?-->
+            <CollectionView ItemsLayout="{x:Static ListItemsLayout.VerticalList}"                             
+                            ItemsSource="{Binding Items}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        
+                        <ContentView> <!-- Notice the additional ContentView here -->
+                <Frame BackgroundColor="White"
+                    HeightRequest="35"
+                    Margin="10, 5"
+                       Visual="Material"
+                    Padding="10"
+                    IsClippedToBounds="True">
+                        
+                        
+                        <Grid VerticalOptions="Center">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="35" />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+
+                            <Label Grid.Column="0"
+                                   VerticalOptions="Center"
+                                   FontAttributes="Bold"
+                                   Text="{Binding Id}" />
+                            <Label Grid.Column="1"
+                                   VerticalOptions="Center"
+                                   Text="{Binding Subject}" />
+                             <Label Grid.Column="2"
+                                    VerticalOptions="Center"
+                                   FontAttributes="Bold"
+                                   Text="{Binding Status}" />
+                                      
+                        </Grid>
+                                </Frame>
+                            </ContentView>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+
+            </StackLayout>
+            
+    </ScrollView>
 </ContentPage>

--- a/VisualChallenge/VisualChallenge/VisualChallengePage.xaml.cs
+++ b/VisualChallenge/VisualChallenge/VisualChallengePage.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
-
+using System.Collections.ObjectModel;
+using VisualChallenge.Models;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
@@ -7,9 +8,47 @@ namespace VisualChallenge
 {
     public partial class VisualChallengePage : ContentPage
     {
+        private ObservableCollection<Item> _items = new ObservableCollection<Item>();
+        public ObservableCollection<Item> Items
+        {
+            get => _items;
+            set => _items = value;
+        }
+
+
+
+
+
         public VisualChallengePage()
         {
             InitializeComponent();
+
+            BindingContext = this;
+
+
+
+            Items.Add(new Item
+            {
+                Id = "1",
+                Status ="Open",
+                Subject = "Subject 123"
+            });
+
+
+            Items.Add(new Item
+            {
+                Id = "2",
+                Status = "Open",
+                Subject = "aaaaaaa cvvvvv"
+            });
+
+
+            Items.Add(new Item
+            {
+                Id = "3",
+                Status = "Open",
+                Subject = "Subject aaaaaa"
+            });
         }
 
         private void Button_Clicked(object sender, EventArgs e)

--- a/VisualChallenge/VisualChallenge/VisualChallengePage.xaml.cs
+++ b/VisualChallenge/VisualChallenge/VisualChallengePage.xaml.cs
@@ -15,6 +15,14 @@ namespace VisualChallenge
             set => _items = value;
         }
 
+        private ObservableCollection<DashboardItem> _dashboardItems = new ObservableCollection<DashboardItem>();
+        public ObservableCollection<DashboardItem> DashboardItems
+        {
+            get => _dashboardItems;
+            set => _dashboardItems = value;
+        }
+
+
 
 
 
@@ -25,12 +33,18 @@ namespace VisualChallenge
 
             BindingContext = this;
 
+            PopulateData();
 
 
+          
+        }
+
+        private void PopulateData()
+        {
             Items.Add(new Item
             {
                 Id = "1",
-                Status ="Open",
+                Status = "Open",
                 Subject = "Subject 123"
             });
 
@@ -49,6 +63,61 @@ namespace VisualChallenge
                 Status = "Open",
                 Subject = "Subject aaaaaa"
             });
+
+            Items.Add(new Item
+            {
+                Id = "4",
+                Status = "Open",
+                Subject = "Subject aaaaaa"
+            });
+
+
+            Items.Add(new Item
+            {
+                Id = "5",
+                Status = "Open",
+                Subject = "Subject aaaaaa"
+            });
+
+
+            Items.Add(new Item
+            {
+                Id = "6",
+                Status = "Open",
+                Subject = "Subject aaaaaa"
+            });
+
+
+
+
+
+            DashboardItems.Add(new DashboardItem
+            {
+                 Number = "1,223",
+                 Description ="Resolved Tickets",
+                 ImageUrl = "https://cdn0.iconfinder.com/data/icons/material-circle-apps/512/icon-email-material-design-512.png"
+            });
+
+            DashboardItems.Add(new DashboardItem
+            {
+                Number = "12m",
+                Description = "Avg. Response",
+                ImageUrl = "https://cdn0.iconfinder.com/data/icons/social-15/200/hangouts-512.png"
+            });
+
+            DashboardItems.Add(new DashboardItem
+            {
+                Number = "11.7m",
+                Description = "Issues",
+                ImageUrl = "https://cdn3.iconfinder.com/data/icons/popular-services-brands-vol-2/512/trello-512.png"
+            });
+
+        
+
+
+
+
+
         }
 
         private void Button_Clicked(object sender, EventArgs e)


### PR DESCRIPTION
I was trying to replicate this UI:

![velocity_7_UserProfile](https://user-images.githubusercontent.com/2139254/54946279-a9108480-4f2f-11e9-8a43-12d08fd74936.png)


Result:
**iOS**
<img width="538" alt="Screen Shot 2019-03-25 at 18 49 44" src="https://user-images.githubusercontent.com/2139254/54953752-e6314280-4f40-11e9-82f6-fb06e60f8f7e.png">


**Android**
<img width="478" alt="Screen Shot 2019-03-25 at 18 52 12" src="https://user-images.githubusercontent.com/2139254/54946387-e2e18b00-4f2f-11e9-83fc-7b4ac54ffdf9.png">


**What went well:**

- Material frames look nice across the both platforms. However in iOS there seems to be a little smudge on the edges, not sure if related with CollectionView cutting some of the Frame layout.
- Buttons look awesome, love the ripple effect, been wanting this for awhile in Xamarin!
- Using CollectionView for the first time, lots of potential, no more custom renderers, specially for the Horizontal Layout

**What didn't:**

- CollectionView Item Spacing , used a  workaround by wrapping in a contentview
- CollectionView tapped animation, is this available? Couldn't find it
- CollectionView header and footer, this would be a plus, my list header is outside the collectionview
- Round Images - this is a must in the near future, having to add custom packages is not that great (in this case I used a round image for testing purposes)
- Button capitalizes all the text. There should be an option to disable this effect

**Want to see next:**
- Round images would be awesome
- Previewer stable, most of the times it fails render
- Elements with custom rounded corners

Overall it is a great experience, for another app I've already tried the entries, they are just missing some customisation options such as height request, setting colors for the underlines and labels.
In the future I plan to try better the Shell .