### PR TITLE
Visual challenge - login page

### DIFF
--- a/VisualChallenge/VisualChallenge/VisualChallenge.csproj
+++ b/VisualChallenge/VisualChallenge/VisualChallenge.csproj
@@ -11,13 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.0.1.206893" />
-    <PackageReference Include="Xamarin.Forms.Visual.Material" Version="4.0.1.206893" />  
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Update="VisualChallengePage.xaml.cs">
       <DependentUpon>VisualChallengePage.xaml</DependentUpon>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Forms" Version="4.0.0.293082-pre8" />
+    <PackageReference Include="Xamarin.Forms.Visual.Material" Version="4.0.0.293082-pre8" />
   </ItemGroup>
 </Project>

--- a/VisualChallenge/VisualChallenge/VisualChallengePage.xaml
+++ b/VisualChallenge/VisualChallenge/VisualChallengePage.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
@@ -12,12 +12,39 @@
 		 Currently there's a bug in shell that will set margins wrong if the content is not in a scrollview
 	-->
 	<ScrollView>
-		<FlexLayout Margin="20" Direction="Column" AlignContent="Center" JustifyContent="SpaceAround">
+		
+         <Grid>
+        <Grid.RowDefinitions>
+             <RowDefinition Height="50" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="80" />
+        </Grid.RowDefinitions>
 
-			<Label Text="Start Here" FontSize="24" HorizontalTextAlignment="Center"/>
 
-			<Button Text="Read More About Visual" Clicked="Button_Clicked" />
+        <StackLayout Orientation="Vertical" Grid.Row="1" >
+            <Label Text="Create a New Account" FontSize="Large" TextColor="Black" HorizontalOptions="Center" Margin="0,10,0,0" />
+            <Entry Text="{Binding Email}" Placeholder="Email" TextColor="Black" PlaceholderColor="Black" Margin="0,5,0,0" />
+            <Entry Text="{Binding UserName}" Placeholder="Username" TextColor="Black" PlaceholderColor="Black" Margin="0,5,0,0" />
+            <Entry Text="{Binding Password}" Placeholder="Password" TextColor="Black" PlaceholderColor="Black" IsPassword="True" Margin="0,5,0,0" />
+            <Entry Text="{Binding ConfirmPassword}" Placeholder="Confirm Password" TextColor="Black" PlaceholderColor="Black" IsPassword="True" Margin="0,5,0,0" />
+            <Button Command="{Binding RegisterCommand}" Text="Register"  TextColor="Black" Margin="0,5,0,0" />
+            <Label Text="{Binding Message,Mode=TwoWay}" TextColor="Black" FontSize="Default" Margin="0,5,0,0" />
+            <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}"  Color="Black" />
+        </StackLayout>
 
-		</FlexLayout>
+        <StackLayout VerticalOptions="End" Orientation="Vertical" Grid.Row="2">
+            <BoxView  HeightRequest="1"  BackgroundColor="Gray" />
+            <StackLayout  Orientation="Horizontal" HorizontalOptions="Center">
+                <StackLayout.GestureRecognizers>
+                    <TapGestureRecognizer Command="{Binding NavigateToLoginPage}" />
+                </StackLayout.GestureRecognizers>
+                <Label Text="Already have an account?"  FontSize="Small" TextColor="Black"  />
+                <Label Text="Log in" FontSize="Small" FontAttributes="Bold" TextColor="Black" />
+            </StackLayout>
+        </StackLayout>
+
+</Grid>
+        
+        
 	</ScrollView>
 </ContentPage>


### PR DESCRIPTION
I used the Xamarin.Forms.Visual for a typical login page that I have created on multiple projects.

The pictures contain the before and after state both for Android and iOS

<img width="957" alt="Screenshot 2019-03-30 at 17 51 19" src="https://user-images.githubusercontent.com/3514710/55278433-ce790600-5314-11e9-83f4-e8df9eb4ea91.png">

<img width="912" alt="Screenshot 2019-03-30 at 17 50 46" src="https://user-images.githubusercontent.com/3514710/55278429-c620cb00-5314-11e9-84f0-53738945a88e.png">


What I liked:

- It is supper easy to use and gain a material design UI within minutes (awesome)

What I noticed:

- Entry seems large for me. I would prefer it a bit smaller both for android and iOS.
- Button got a dark background color.
- Bottom login label large margin.

Would like to see:

- More controls
